### PR TITLE
Add docs that .spec.namespace is immutable for App CRD 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add note to `.spec.namespace` for `App` CRD that this field cannot be changed.
+
 ## [0.2.0] - 2021-12-15
 
 ### Added

--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -76,8 +76,8 @@ type AppSpec struct {
 	// Name is the name of the app to be deployed.
 	// e.g. kubernetes-prometheus
 	Name string `json:"name"`
-	// Namespace is the namespace where the app should be deployed.
-	// e.g. monitoring
+	// Namespace is the target namespace where the app should be deployed
+	// e.g. monitoring, it cannot be changed.
 	Namespace string `json:"namespace"`
 	// +kubebuilder:validation:Optional
 	// +nullable

--- a/config/crd/application.giantswarm.io_apps.yaml
+++ b/config/crd/application.giantswarm.io_apps.yaml
@@ -162,8 +162,8 @@ spec:
                 description: Name is the name of the app to be deployed. e.g. kubernetes-prometheus
                 type: string
               namespace:
-                description: Namespace is the namespace where the app should be deployed.
-                  e.g. monitoring
+                description: Namespace is the target namespace where the app should
+                  be deployed e.g. monitoring, it cannot be changed.
                 type: string
               namespaceConfig:
                 description: NamespaceConfig is the namespace config to be applied


### PR DESCRIPTION
Towards https://github.com/giantswarm/app-admission-controller/pull/208

`.spec.namespace` is used to specify the helm release namespace which can't be changed. With https://github.com/giantswarm/app-admission-controller/pull/208 this will be blocked by the admission controller.

This updates the App CRD docs.

## Checklist

- [x] Update changelog in CHANGELOG.md.
